### PR TITLE
Fix /game/live/xxx URL issue

### DIFF
--- a/js/chessMoveReminder.js
+++ b/js/chessMoveReminder.js
@@ -5,11 +5,13 @@ function randomPositiveNumber(max) {
     return Math.floor(Math.random() * max) + 1;
 }
 
-function semiRandomPositiveNumber(max) {
-    let result = randomPositiveNumber(max);
-    while (recentRandomNumber === result) {
+function randomPositiveNumberWithoutRepeat(max) {
+    let result;
+    do {
         result = randomPositiveNumber(max);
     }
+    while (recentRandomNumber === result);
+
     recentRandomNumber = result;
     return result;
 }
@@ -31,7 +33,7 @@ function chessMoveReminder() {
     let playAudio = function(who) {
         let audioUrl = 'audio/SoundEffect/SoundEffect.mp3';
         if (who === 'HikaruGotham') {
-            audioUrl = 'audio/HikaruGotham/' + semiRandomPositiveNumber(20) + '.wav';
+            audioUrl = 'audio/HikaruGotham/' + randomPositiveNumberWithoutRepeat(20) + '.wav';
         }
         audio = new Audio(chrome.runtime.getURL(audioUrl));
         try {
@@ -42,16 +44,18 @@ function chessMoveReminder() {
     }
 
     let target = document.querySelector('#board-layout-player-bottom .clock-component');
-
     if (target !== null) {
         if (observer !== undefined) {
             observer.disconnect();
         }
         observer = new MutationObserver(function(mutations) {
             mutations.forEach(function(mutation) {
-                let currentClock = mutation.target.attributes.getNamedItem('data-clock').value;
+                let currentClock = mutation.target.innerText;
                 clearTimeout(timer);
-                let isTurn = mutation.target.classList.contains('clock-playerTurn');
+                // For some reason chess.com/live#g=xxx uses clock-playerTurn
+                // whereas chess.com/game/live/xxx uses clock-player-turn
+                let isTurn = mutation.target.classList.contains('clock-playerTurn')
+                    || mutation.target.classList.contains('clock-player-turn');
                 if (!isTurn && audio !== undefined) {
                     audio.pause();
                 }


### PR DESCRIPTION
The structure of the page on `/game/live/xxx` is different from `/live#g=xxx`. In addition, `/game/live/xxx` uses the class `clock-player-turn` whereas `/live#g=xxx` uses the class `clock-playerTurn` for some unexplained reason. This fixes the issue of the Play->Play workflow.