### PR TITLE
Allow plugin to be enabled in chess.com/play/online

### DIFF
--- a/manifest-chrome.json
+++ b/manifest-chrome.json
@@ -7,6 +7,7 @@
             "matches": [
                 "*://*.chess.com/live*",
                 "*://*.chess.com/game/live*",
+                "*://*.chess.com/play/online*",
                 "*://*.lichess.org/*"
             ],
             "js": [

--- a/manifest-firefox.json
+++ b/manifest-firefox.json
@@ -7,6 +7,7 @@
             "matches": [
                 "*://*.chess.com/live*",
                 "*://*.chess.com/game/live*",
+                "*://*.chess.com/play/online*",
                 "*://*.lichess.org/*"
             ],
             "js": [


### PR DESCRIPTION
Hey!
Nice plugin :) very fun and useful for slow heads like mine.
I found an issue with the current version of chess.com. The plugin was simply not running from https://www.chess.com/play/online, which I think is the main entry point now for playing against others. This PR adds the url to the manifest(s) and should make it work again (at least it does for me!)
Cheers,
Ivan.
